### PR TITLE
Improve wording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cosmian_ffi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmian_ffi"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   "Théophile Brezot <theophile.brezot@cosmian.com>",
 ]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,10 +7,10 @@ use thiserror::Error;
 
 #[derive(Clone, Error, Debug)]
 pub enum FfiError {
-    #[error("Invalid NULL pointer: {0}")]
+    #[error("{0} shouldn't be null")]
     NullPointer(String),
 
-    #[error("FFI error: {0}")]
+    #[error("{0}")]
     Generic(String),
 }
 
@@ -121,6 +121,6 @@ mod tests {
             h_get_error(ptr, &mut len);
             String::from_utf8(bytes[..len as usize].to_vec()).unwrap()
         };
-        assert!(res.contains("NULL pointer"));
+        assert!(res.contains("shouldn't be null"));
     }
 }


### PR DESCRIPTION
Since FfiErrors are returned to the user we want them as clean as possible. The user doesn't need to understand what is a FFI to understand the error.

Before: 
> Invalid NULL pointer: master key
> FFI error: While parsing master key for Findex search, wrong size when parsing bytes: 4 given should be 16

After:
> master key shouldn't be null
> While parsing master key for Findex search, wrong size when parsing bytes: 4 given should be 16